### PR TITLE
Fix certain Version qualifiers from unintentionally being marked unreleased

### DIFF
--- a/src/main/scala/org/jmotor/sbt/service/VersionServiceImpl.scala
+++ b/src/main/scala/org/jmotor/sbt/service/VersionServiceImpl.scala
@@ -82,7 +82,7 @@ class VersionServiceImpl(
   private def getModuleStatus(mv: DefaultArtifactVersion, released: Boolean, qualifierOpt: Option[String], versions: Seq[ArtifactVersion]) = {
     val releases = versions.filter {
       case av if Option(av.getQualifier).isDefined ⇒
-        !Versions.UNRELEASED.exists(q ⇒ av.getQualifier.toLowerCase.contains(q))
+        !Versions.UNRELEASED.exists(q ⇒ av.getQualifier.toLowerCase.equals(q))
       case _ ⇒ true
     }
     val matches = qualifierOpt match {

--- a/src/main/scala/org/jmotor/sbt/service/VersionServiceImpl.scala
+++ b/src/main/scala/org/jmotor/sbt/service/VersionServiceImpl.scala
@@ -52,7 +52,7 @@ class VersionServiceImpl(
   private[this] def check(module: ModuleID, sbtSettings: Option[(String, String)] = None): Future[ModuleStatus] = {
     val mv = new DefaultArtifactVersion(module.revision)
     val released = if (Option(mv.getQualifier).isDefined) {
-      !Versions.UNRELEASED.exists(q ⇒ mv.getQualifier.toLowerCase.contains(q))
+      !Versions.UNRELEASED.exists(q ⇒ mv.getQualifier.toLowerCase.equals(q))
     } else {
       true
     }


### PR DESCRIPTION
depedencyUpdates command does not work when using git branch name qualifiers. We have branches for various environments such as "1.1.2-prod", "1.3.6-marketing", "3.2.1-development" managed by bintray or artifactory.

Since "prod" contains pr, it is marked as unreleased and upgraded to 1.1.2. "marketing" contains an "m" so it is marked as unreleased. "development" contains an m as well so it is also marked as unreleased.

What we need is for the prod qualifier to stick when using dependencyUpdates instead of it being lost.

I would suggest that if the qualifier actually matches an element in this list instead of just containing the string would be a better way of automatically marking a version as unreleased, aside from making it an argument that we can override with the sbt config (which is more time to implement that may be necessary)

Versions.UNRELEASED = "pr", "m", "beta", "rc", "alpha", "snapshot", "snap"