### PR TITLE
Allow to narrow down the dependencies & allow snapshots as latest version

### DIFF
--- a/src/main/scala/org/jmotor/sbt/Reporter.scala
+++ b/src/main/scala/org/jmotor/sbt/Reporter.scala
@@ -26,8 +26,7 @@ class Reporter(versionService: VersionService, organizationsToInclude: Seq[Strin
     Future.traverse(dependencies.filter(filterByOrganization))(versionService.checkForUpdates).map(_.sortBy(_.status.id))
   }
 
-  def pluginUpdates(sbtBinaryVersion: String, project: ResolvedProject,
-                    ): Future[Seq[ModuleStatus]] = {
+  def pluginUpdates(sbtBinaryVersion: String, project: ResolvedProject): Future[Seq[ModuleStatus]] = {
     val dir = Paths.get(project.base.getPath, "project")
     val sbtScalaBinaryVersion = getSbtScalaBinaryVersion(sbtBinaryVersion)
     Future.traverse(plugins(dir)) { module ⇒

--- a/src/main/scala/org/jmotor/sbt/plugin/DependencyUpdatesKeys.scala
+++ b/src/main/scala/org/jmotor/sbt/plugin/DependencyUpdatesKeys.scala
@@ -18,6 +18,8 @@ trait DependencyUpdatesKeys {
 
   lazy val dependencyUpgradeComponentSorter: SettingKey[ComponentSorter] = settingKey[ComponentSorter]("Component sorter")
 
+  lazy val onlyIncludeOrganizations: SettingKey[Seq[String]] = settingKey[Seq[String]]("Only include dependencies from this organizations")
+
   lazy val dependencyUpgradeModuleNames: SettingKey[Map[String, String]] = settingKey[Map[String, String]]("Module name mappings")
 
 }

--- a/src/main/scala/org/jmotor/sbt/plugin/DependencyUpdatesKeys.scala
+++ b/src/main/scala/org/jmotor/sbt/plugin/DependencyUpdatesKeys.scala
@@ -20,6 +20,8 @@ trait DependencyUpdatesKeys {
 
   lazy val onlyIncludeOrganizations: SettingKey[Seq[String]] = settingKey[Seq[String]]("Only include dependencies from this organizations")
 
+  lazy val allowSnapshotVersions: SettingKey[Boolean] = settingKey[Boolean]("Accept SNAPSHOT versions as latest version")
+
   lazy val dependencyUpgradeModuleNames: SettingKey[Map[String, String]] = settingKey[Map[String, String]]("Module name mappings")
 
 }

--- a/src/main/scala/org/jmotor/sbt/plugin/DependencyUpdatesSettings.scala
+++ b/src/main/scala/org/jmotor/sbt/plugin/DependencyUpdatesSettings.scala
@@ -27,11 +27,12 @@ object DependencyUpdatesSettings {
     dependencyUpgradeComponentSorter := ComponentSorter.ByLength,
     dependencyUpgradeModuleNames := Map.empty[String, String],
     onlyIncludeOrganizations := Seq(),
+    allowSnapshotVersions := false,
     dependencyUpdates := {
-      val reporter = Reporter(VersionService(
-        sLog.value, scalaVersion.value, scalaBinaryVersion.value, fullResolvers.value, credentials.value),
-        organizationsToInclude = onlyIncludeOrganizations.value
-      )
+      val reporter = Reporter(
+        VersionService(
+          sLog.value, scalaVersion.value, scalaBinaryVersion.value, fullResolvers.value, credentials.value, allowSnapshots = allowSnapshotVersions.value),
+        organizationsToInclude = onlyIncludeOrganizations.value)
       val bar = new ProgressBar("[info] Checking", "[info] Done checking.")
       bar.start()
 
@@ -52,10 +53,10 @@ object DependencyUpdatesSettings {
     },
     dependencyUpgrade := {
       val logger = sLog.value
-      val reporter = Reporter(VersionService(
-        logger, scalaVersion.value, scalaBinaryVersion.value, fullResolvers.value, credentials.value),
-        organizationsToInclude = onlyIncludeOrganizations.value
-      )
+      val reporter = Reporter(
+        VersionService(
+          logger, scalaVersion.value, scalaBinaryVersion.value, fullResolvers.value, credentials.value, allowSnapshots = allowSnapshotVersions.value),
+        organizationsToInclude = onlyIncludeOrganizations.value)
       val bar = new ProgressBar("[info] Upgrading", "[info] Done upgrading.")
       bar.start()
 

--- a/src/main/scala/org/jmotor/sbt/service/VersionService.scala
+++ b/src/main/scala/org/jmotor/sbt/service/VersionService.scala
@@ -25,8 +25,8 @@ trait VersionService {
 object VersionService {
 
   def apply(logger: Logger, scalaVersion: String, scalaBinaryVersion: String,
-            resolvers: Seq[Resolver], credentials: Seq[Credentials]): VersionService = {
-    new VersionServiceImpl(logger, scalaVersion, scalaBinaryVersion, resolvers, credentials)
+            resolvers: Seq[Resolver], credentials: Seq[Credentials], allowSnapshots: Boolean = false): VersionService = {
+    new VersionServiceImpl(logger, scalaVersion, scalaBinaryVersion, resolvers, credentials, allowSnapshots)
   }
 
 }

--- a/src/main/scala/org/jmotor/sbt/service/VersionServiceImpl.scala
+++ b/src/main/scala/org/jmotor/sbt/service/VersionServiceImpl.scala
@@ -33,7 +33,8 @@ class VersionServiceImpl(
     scalaVersion:       String,
     scalaBinaryVersion: String,
     resolvers:          Seq[Resolver],
-    credentials:        Seq[Credentials]) extends VersionService {
+    credentials:        Seq[Credentials],
+    allowSnapshots:     Boolean          = false) extends VersionService {
 
   private[this] implicit lazy val client: AsyncHttpClient = {
     import org.asynchttpclient.Dsl._
@@ -76,7 +77,7 @@ class VersionServiceImpl(
   }
 
   private def getModuleStatus(mv: DefaultArtifactVersion, released: Boolean, qualifierOpt: Option[String], versions: Seq[ArtifactVersion]) = {
-    val releases = versions.filter(Versions.isReleaseVersion)
+    val releases = if (allowSnapshots) versions else versions.filter(Versions.isReleaseVersion)
     val matches = qualifierOpt match {
       case None ⇒
         releases.filter { av ⇒

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2.2-NA-SNAPSHOT"
+version in ThisBuild := "1.2.2-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2.2-SNAPSHOT"
+version in ThisBuild := "1.2.2-NA-SNAPSHOT"


### PR DESCRIPTION
Hi,

I added two features:

the possiblity to only update dependencies with given organizations
=> this is useful if you only want to update the dependencies under your control / to fix some dependen cies

the possibility to allow snapshots as latest versions
=> useful in the context of CI and own dependencies; e.g. set the dependencie of library A to the latest snapshot so dependent project B can be automatically triggered when A is changed in develpp