### PR TITLE
Add support for resolvers with a custom protocol handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ lib_managed/
 src_managed/
 project/boot/
 project/plugins/project/
+project/metals.sbt
+project/project
 
 # Scala-IDE specific
 .scala_dependencies
@@ -18,3 +20,6 @@ project/plugins/project/
 .idea
 
 .bsp
+.bloop
+.metals
+.vscode

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,8 @@ inThisBuild(List(
       "yanbo.ai@gmail.com",
       url("https://aiyanbo.github.io/")
     )
-  )
+  ),
+  Test / fork := true
 ))
 
 coverageScalacPluginVersion := "2.0.10"

--- a/src/main/scala/org/jmotor/sbt/artifact/metadata/MetadataLoader.scala
+++ b/src/main/scala/org/jmotor/sbt/artifact/metadata/MetadataLoader.scala
@@ -5,12 +5,13 @@ import org.apache.ivy.util.{CopyProgressEvent, CopyProgressListener}
 import org.apache.maven.artifact.versioning.ArtifactVersion
 import org.jmotor.sbt.artifact.exception.ArtifactNotFoundException
 
-import java.net.URL
+import java.net.{URL, URI}
 import java.nio.file.{Files, Path, Paths}
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.io.Source
 import java.io.ByteArrayInputStream
 import java.net.HttpURLConnection
+import java.io.FileOutputStream
 
 /**
  * Component: Description: Date: 2018/2/8
@@ -29,14 +30,25 @@ trait MetadataLoader {
   def download(organization: String, artifactId: String, url: String)(implicit ec: ExecutionContext): Future[Path] =
     Future {
       try {
-        val src        = new URL(url)
+        val src        = new URI(url).toURL()
         val connection = src.openConnection()
 
         Option(connection.getInputStream()).map { is =>
           val path = Files.createTempFile(s"maven-metadata-$organization-$artifactId", ".xml")
-          // might better write via file output stream
-          Files.write(path, is.readAllBytes())
-          path
+          val os   = new FileOutputStream(path.toAbsolutePath.toString())
+
+          try {
+            val buffer    = new Array[Byte](8192)
+            var bytesRead = is.read(buffer)
+            while (bytesRead >= 0) {
+              os.write(buffer, 0, bytesRead)
+              bytesRead = is.read(buffer)
+            }
+            path
+          } finally {
+            is.close()
+            os.close()
+          }
         }
       } catch {
         case e: java.io.FileNotFoundException => None

--- a/src/main/scala/org/jmotor/sbt/artifact/metadata/loader/MavenRepoMetadataLoader.scala
+++ b/src/main/scala/org/jmotor/sbt/artifact/metadata/loader/MavenRepoMetadataLoader.scala
@@ -19,7 +19,7 @@ class MavenRepoMetadataLoader(url: String)(implicit ec: ExecutionContext) extend
 
   private[this] lazy val (protocol, base) = {
     val u = new URI(url)
-    (u.getScheme -> u.getHost)
+    (u.getScheme + "://" -> u.getRawSchemeSpecificPart.stripPrefix("//"))
   }
 
   override def getVersions(

--- a/src/main/scala/org/jmotor/sbt/artifact/metadata/loader/MavenRepoMetadataLoader.scala
+++ b/src/main/scala/org/jmotor/sbt/artifact/metadata/loader/MavenRepoMetadataLoader.scala
@@ -27,8 +27,9 @@ class MavenRepoMetadataLoader(url: String)(implicit ec: ExecutionContext) extend
     artifactId: String,
     attrs: Map[String, String]
   ): Future[Seq[ArtifactVersion]] = {
-    val location =
-      protocol + s"$base/${organization.split('.').mkString("/")}/$artifactId/maven-metadata.xml"
+    val location = new URI(s"$protocol$base/${organization.split('.').mkString("/")}/$artifactId/maven-metadata.xml")
+      .normalize()
+      .toString()
     download(organization, artifactId, location).map { file =>
       val stream = Files.newInputStream(file)
       try {

--- a/src/main/scala/org/jmotor/sbt/artifact/metadata/loader/MavenRepoMetadataLoader.scala
+++ b/src/main/scala/org/jmotor/sbt/artifact/metadata/loader/MavenRepoMetadataLoader.scala
@@ -4,7 +4,7 @@ import org.apache.maven.artifact.versioning.{ArtifactVersion, DefaultArtifactVer
 import org.jmotor.sbt.artifact.exception.ArtifactNotFoundException
 import org.jmotor.sbt.artifact.metadata.MetadataLoader
 
-import java.net.URL
+import java.net.URI
 import java.nio.file.{Files, Paths}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.xml.XML
@@ -18,8 +18,8 @@ import scala.xml.XML
 class MavenRepoMetadataLoader(url: String)(implicit ec: ExecutionContext) extends MetadataLoader {
 
   private[this] lazy val (protocol, base) = {
-    val u = new URL(url)
-    u.getProtocol + "://" -> url.replace(s"${u.getProtocol}://", "")
+    val u = new URI(url)
+    (u.getScheme -> u.getHost)
   }
 
   override def getVersions(
@@ -28,7 +28,7 @@ class MavenRepoMetadataLoader(url: String)(implicit ec: ExecutionContext) extend
     attrs: Map[String, String]
   ): Future[Seq[ArtifactVersion]] = {
     val location =
-      protocol + Paths.get(base, organization.split('.').mkString("/"), artifactId, "maven-metadata.xml").toString
+      protocol + s"$base/${organization.split('.').mkString("/")}/$artifactId/maven-metadata.xml"
     download(organization, artifactId, location).map { file =>
       val stream = Files.newInputStream(file)
       try {

--- a/src/main/scala/org/jmotor/sbt/metadata/MetadataLoaderGroup.scala
+++ b/src/main/scala/org/jmotor/sbt/metadata/MetadataLoaderGroup.scala
@@ -54,7 +54,7 @@ class MetadataLoaderGroup(scalaVersion: String, scalaBinaryVersion: String, load
     sbtSettings: Option[(String, String)]
   ): (String, Map[String, String]) = {
     val remapVersion = module.crossVersion match {
-      case _: Disabled        => None
+      case _: Disabled        => sbtSettings.map { case (sbt, scala) => s"${scala}_$sbt" }
       case binary: Binary     => Option(binary.prefix + scalaBinaryVersion)
       case _: Full            => Option(scalaVersion)
       case _: Patch           => Option(scalaVersion)

--- a/src/main/scala/org/jmotor/sbt/metadata/MetadataLoaderGroup.scala
+++ b/src/main/scala/org/jmotor/sbt/metadata/MetadataLoaderGroup.scala
@@ -54,7 +54,7 @@ class MetadataLoaderGroup(scalaVersion: String, scalaBinaryVersion: String, load
     sbtSettings: Option[(String, String)]
   ): (String, Map[String, String]) = {
     val remapVersion = module.crossVersion match {
-      case _: Disabled        => sbtSettings.map { case (sbt, scala) => s"${scala}_$sbt" }
+      case _: Disabled        => None
       case binary: Binary     => Option(binary.prefix + scalaBinaryVersion)
       case _: Full            => Option(scalaVersion)
       case _: Patch           => Option(scalaVersion)

--- a/src/main/scala/org/jmotor/sbt/service/VersionServiceImpl.scala
+++ b/src/main/scala/org/jmotor/sbt/service/VersionServiceImpl.scala
@@ -18,6 +18,7 @@ import sbt.util.Logger
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.util.control.NonFatal
+import scala.util.{Failure, Success}
 
 /**
  * Component: Description: Date: 2018/2/9
@@ -84,8 +85,11 @@ class VersionServiceImpl(logger: Logger, scalaVersion: String, scalaBinaryVersio
     val loaders: Seq[MetadataLoader] = resolvers.map {
       case repo: MavenRepository =>
         val url = repo.root
-        if (isRemote(url) && scala.util.Try(new java.net.URL(url)).isSuccess) {
-          Option(new MavenRepoMetadataLoader(url))
+        if (isRemote(url)) {
+          scala.util.Try(new java.net.URL(url)) match {
+            case Failure(e) => logger.err(s"""Invalid URL "$url" for Maven repository: ${e.getMessage}"""); None
+            case Success(_) => Option(new MavenRepoMetadataLoader(url))
+          }
         } else {
           None
         }

--- a/src/main/scala/org/jmotor/sbt/service/VersionServiceImpl.scala
+++ b/src/main/scala/org/jmotor/sbt/service/VersionServiceImpl.scala
@@ -86,7 +86,7 @@ class VersionServiceImpl(logger: Logger, scalaVersion: String, scalaBinaryVersio
       case repo: MavenRepository =>
         val url = repo.root
         if (isRemote(url)) {
-          scala.util.Try(new java.net.URL(url)) match {
+          scala.util.Try(new java.net.URI(url).toURL()) match {
             case Failure(e) => logger.err(s"""Invalid URL "$url" for Maven repository: ${e.getMessage}"""); None
             case Success(_) => Option(new MavenRepoMetadataLoader(url))
           }

--- a/src/main/scala/org/jmotor/sbt/service/VersionServiceImpl.scala
+++ b/src/main/scala/org/jmotor/sbt/service/VersionServiceImpl.scala
@@ -84,7 +84,7 @@ class VersionServiceImpl(logger: Logger, scalaVersion: String, scalaBinaryVersio
     val loaders: Seq[MetadataLoader] = resolvers.map {
       case repo: MavenRepository =>
         val url = repo.root
-        if (isRemote(url)) {
+        if (isRemote(url) && scala.util.Try(new java.net.URL(url)).isSuccess) {
           Option(new MavenRepoMetadataLoader(url))
         } else {
           None
@@ -106,6 +106,6 @@ class VersionServiceImpl(logger: Logger, scalaVersion: String, scalaBinaryVersio
   }
 
   private[this] def isRemote(url: String): Boolean =
-    url.startsWith("http://") || url.startsWith("https://")
+    !url.startsWith("file://") && !url.startsWith("jar://")
 
 }

--- a/src/main/scala/org/jmotor/sbt/service/VersionServiceImpl.scala
+++ b/src/main/scala/org/jmotor/sbt/service/VersionServiceImpl.scala
@@ -27,17 +27,17 @@ import scala.util.{Failure, Success}
  * AI
  */
 class VersionServiceImpl(logger: Logger, scalaVersion: String, scalaBinaryVersion: String, resolvers: Seq[Resolver])
-  extends VersionService {
+    extends VersionService {
 
   private[this] lazy val groups = getLoaderGroups(resolvers)
 
   override def checkForUpdates(module: ModuleID): Future[ModuleStatus] = check(module)
 
   override def checkPluginForUpdates(
-                                      module: ModuleID,
-                                      sbtBinaryVersion: String,
-                                      sbtScalaBinaryVersion: String
-                                    ): Future[ModuleStatus] =
+    module: ModuleID,
+    sbtBinaryVersion: String,
+    sbtScalaBinaryVersion: String
+  ): Future[ModuleStatus] =
     check(module, Option(sbtBinaryVersion -> sbtScalaBinaryVersion))
 
   private[this] def check(module: ModuleID, sbtSettings: Option[(String, String)] = None): Future[ModuleStatus] = {
@@ -110,6 +110,6 @@ class VersionServiceImpl(logger: Logger, scalaVersion: String, scalaBinaryVersio
   }
 
   private[this] def isRemote(url: String): Boolean =
-    !url.startsWith("file://") && !url.startsWith("jar://")
+    !url.startsWith("file:") && !url.startsWith("jar:")
 
 }

--- a/src/main/scala/org/jmotor/sbt/service/VersionServiceImpl.scala
+++ b/src/main/scala/org/jmotor/sbt/service/VersionServiceImpl.scala
@@ -27,17 +27,17 @@ import scala.util.{Failure, Success}
  * AI
  */
 class VersionServiceImpl(logger: Logger, scalaVersion: String, scalaBinaryVersion: String, resolvers: Seq[Resolver])
-    extends VersionService {
+  extends VersionService {
 
   private[this] lazy val groups = getLoaderGroups(resolvers)
 
   override def checkForUpdates(module: ModuleID): Future[ModuleStatus] = check(module)
 
   override def checkPluginForUpdates(
-    module: ModuleID,
-    sbtBinaryVersion: String,
-    sbtScalaBinaryVersion: String
-  ): Future[ModuleStatus] =
+                                      module: ModuleID,
+                                      sbtBinaryVersion: String,
+                                      sbtScalaBinaryVersion: String
+                                    ): Future[ModuleStatus] =
     check(module, Option(sbtBinaryVersion -> sbtScalaBinaryVersion))
 
   private[this] def check(module: ModuleID, sbtSettings: Option[(String, String)] = None): Future[ModuleStatus] = {

--- a/src/test/scala/org/jmotor/sbt/service/VersionServiceSpec.scala
+++ b/src/test/scala/org/jmotor/sbt/service/VersionServiceSpec.scala
@@ -37,7 +37,7 @@ class VersionServiceSpec extends AnyFunSuite {
     val versionService =
       VersionService(Logger.Null, "2.12.4", "2.12", resolvers, Seq.empty)
     val future = versionService.checkPluginForUpdates(
-      ModuleID("org.jetbrains", "sbt-idea-shell", "2017.2"),
+      ModuleID("ch.epfl.scala", "sbt-bloop", "1.5.13"),
       "1.0",
       "2.12"
     )

--- a/src/test/scala/org/jmotor/sbt/service/VersionServiceSpec.scala
+++ b/src/test/scala/org/jmotor/sbt/service/VersionServiceSpec.scala
@@ -37,7 +37,7 @@ class VersionServiceSpec extends AnyFunSuite {
     val versionService =
       VersionService(Logger.Null, "2.12.4", "2.12", resolvers, Seq.empty)
     val future = versionService.checkPluginForUpdates(
-      ModuleID("ch.epfl.scala", "sbt-bloop", "1.5.13"),
+      ModuleID("org.jetbrains", "sbt-idea-shell", "2017.2"),
       "1.0",
       "2.12"
     )

--- a/version.sbt
+++ b/version.sbt
@@ -1,3 +1,3 @@
-ThisBuild / version := "1.2.8"
+ThisBuild / version := "1.2.9-SNAPSHOT"
 
 ThisBuild / versionScheme := Some("semver-spec")


### PR DESCRIPTION
Hi, we have some resolvers using a custom protocol handler that can be registered globally for example like in this plugin https://github.com/abdolence/sbt-gcs-resolver , but `sbt-dependency-updates` wasn't able to pick up updates for those.

After a closer look it seemed to work with http/https only, so I tried to make it work with custom handler and came up with this update. 
Have been using it locally for some time now and it seems to work well.