### PR TITLE
Use credentials to authenticate with maven repos, and resolve module name clashes in dependencyUpgradeModuleNames

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,14 +80,16 @@ You can download an example project with this layout here:
 
 ## Settings
 
-- `dependencyUpgradeModuleNames`: a setting to customize the mapping of module name
+- `dependencyUpgradeModuleNames`: a setting to customize the mapping of module name (or `"org-name:module-name"`)
 
 E.g. in `build.sbt` you can change configuration settings like this:
 
 ```scala
   dependencyUpgradeModuleNames := Map(
     "slf4j-simple" -> "slf4j",
-    "undertow.*" -> "undertow"
+    "undertow.*"   -> "undertow",
+    "org.some:some-module"  -> "someModule",      // "org.some"  % "some-module" uses "someModule" as version variable name
+    "org.other:some-module" -> "someOtherModule", // "org.other" % "some-module" uses "someOtherModule" as version variable name
   )
 ```
 

--- a/src/main/scala/org/jmotor/sbt/plugin/DependencyUpdatesSettings.scala
+++ b/src/main/scala/org/jmotor/sbt/plugin/DependencyUpdatesSettings.scala
@@ -25,7 +25,13 @@ object DependencyUpdatesSettings {
     dependencyUpgradeModuleNames     := Map.empty[String, String],
     dependencyUpdates := {
       val reporter = Reporter(
-        VersionService(sLog.value, scalaVersion.value, scalaBinaryVersion.value, fullResolvers.value, credentials.value)
+        VersionService(
+          sLog.value,
+          scalaVersion.value,
+          scalaBinaryVersion.value,
+          fullResolvers.value,
+          allCredentials.value ++ credentials.value
+        )
       )
       val futureDependencyUpdates   = reporter.dependencyUpdates(libraryDependencies.value)
       val futureGlobalPluginUpdates = reporter.globalPluginUpdates(sbtBinaryVersion.value)
@@ -47,7 +53,13 @@ object DependencyUpdatesSettings {
     dependencyUpgrade := {
       val logger = sLog.value
       val reporter = Reporter(
-        VersionService(logger, scalaVersion.value, scalaBinaryVersion.value, fullResolvers.value, credentials.value)
+        VersionService(
+          logger,
+          scalaVersion.value,
+          scalaBinaryVersion.value,
+          fullResolvers.value,
+          allCredentials.value ++ credentials.value
+        )
       )
       val futureDependencyUpdates = reporter.dependencyUpdates(libraryDependencies.value)
       val futurePluginUpdates     = reporter.pluginUpdates(sbtBinaryVersion.value, thisProject.value)

--- a/src/main/scala/org/jmotor/sbt/service/VersionService.scala
+++ b/src/main/scala/org/jmotor/sbt/service/VersionService.scala
@@ -34,6 +34,6 @@ object VersionService {
     resolvers: Seq[Resolver],
     credentials: Seq[Credentials]
   ): VersionService =
-    new VersionServiceImpl(logger, scalaVersion, scalaBinaryVersion, resolvers)
+    new VersionServiceImpl(logger, scalaVersion, scalaBinaryVersion, resolvers, credentials)
 
 }


### PR DESCRIPTION
Love this plugin, thank you!

Three changes in one PR, hope that's ok. (These were blocking me from using it at work :-))

First, need to pass in credentials for private maven repos (not implemented for ivy yet).

I also ran into the case where we have dependencies with the same name from different orgs, so I added support for `org:module` mappings in dependencyUpgradeModuleNames (explained in the README updates)

Finally, tweak the final version logic to also rule out those suffixed with build numbers / shas.